### PR TITLE
feat: add image support using blossom server

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -55,3 +55,15 @@ a {
   flex-direction: column;
   gap: 5px;
 }
+
+.blossom-image-thumbnail {
+  width: 100px;
+}
+
+.descriptor-list {
+  display: flex;
+}
+
+.descriptor {
+  display: flex;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const App = () => {
           <Link to="/">Home</Link>
           <Link to="/pubkeys">Pubkeys</Link>
           <Link to="/kinds">Kinds</Link>
+          <Link to="/blossom">Blossom</Link>
         </div>
       </div>
       <Outlet />

--- a/src/components/Blossom/Blossom.tsx
+++ b/src/components/Blossom/Blossom.tsx
@@ -1,0 +1,122 @@
+import { ChangeEvent, useEffect, useState } from "react"
+import { fromEvent, fromHash, fromPayload } from "../../utils/blossom.utils";
+import { MANAGER_API_BASE_URL } from "../../utils/general.utils";
+import { loadWhitelist } from "../Pubkeys/api";
+
+
+interface Descriptor {
+    url: string;
+    sha256: string;
+}
+
+export function Blossom() {
+    const [file, setFile] = useState<File>();
+    const [descrptors, setDescriptors] = useState<Descriptor[]>([]);
+
+    const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files) {
+            setFile(e.target.files[0]);
+        }
+    }
+
+    const handleUpload = async () => {
+        if (!file) return;
+
+        const hash = await fromPayload(file);
+        const response = await fetch(`${MANAGER_API_BASE_URL}/upload`, {
+            method: 'PUT', headers: {
+                'content-type': file.type,
+                'content-length': `${file.size}`,
+                Authorization: `Nostr ${hash}`
+            },
+            body: file,
+        });
+
+        if (response.ok) {
+            const result = await response.json();
+            if (result) {
+                loadData();
+            }
+        }
+    }
+    const loadData = async () => {
+        const pubkeys = await loadWhitelist();
+        const hash = await fromEvent();
+        const descriptors: Descriptor[] = [];
+
+        for (let i = 0; i < pubkeys.length; i++) {
+            const response = await fetch(`${MANAGER_API_BASE_URL}/list/${pubkeys[i].pubkey}`, {
+                method: 'GET', headers: {
+                    Authorization: `Nostr ${hash}`
+                },
+            });
+            if (response.ok) {
+                const descriptorList = await response.json() as Descriptor[];
+                descriptors.push(...descriptorList);
+            }
+        }
+        setDescriptors(descriptors);
+    }
+
+    const deleteBlob = async (hash: string) => {
+        const authToken = await fromHash(hash);
+
+        const response = await fetch(
+            `${MANAGER_API_BASE_URL}/${hash}`,
+            { method: 'DELETE', headers: { Authorization: `Nostr ${authToken}` } }
+        );
+
+        if (response.ok) {
+            loadData();
+        }
+    }
+
+    useEffect(() => {
+        loadData();
+    }, []);
+
+    return (
+        <>
+            <h1>Blossom</h1>
+            <input type="file" onChange={handleFileChange} />
+            <button onClick={handleUpload}>Upload</button>
+            <hr />
+            <div>
+                <h3>Blobs</h3>
+                <div className="descriptor-list">
+                    {descrptors.map(d =>
+                        <Descriptor descriptor={d} deleteFunc={deleteBlob} />
+                    )}
+                </div>
+            </div>
+        </>
+    )
+}
+
+interface DescriptorProps {
+    descriptor: Descriptor;
+    deleteFunc: (sha256: string) => Promise<void>;
+};
+
+function Descriptor({ descriptor, deleteFunc }: DescriptorProps) {
+    return (
+        <div className="descriptor" key={descriptor.sha256}>
+            {
+                isImageUrl(descriptor.url) ?
+                    <img className="blossom-image-thumbnail" src={descriptor.url.replace('https://', 'http://')} /> :
+                    <a href={descriptor.url}>{descriptor.url}</a>
+            }
+            <span className="whitelist-remove" onClick={() => deleteFunc(descriptor.sha256)}>❌</span>
+        </div>
+    )
+}
+
+function isImageUrl(str: string) {
+    return (
+        str.indexOf('png') > -1 ||
+        str.indexOf('jpg') > -1 ||
+        str.indexOf('jpeg') > -1 ||
+        str.indexOf('gif') > -1 ||
+        str.indexOf('webp') > -1
+    );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Route, Routes } from 'react-router';
 import Pubkeys from './components/Pubkeys/Pubkeys';
 import Kinds from './components/Kinds/Kinds';
 import Metadata from './components/Metadata/Metadata';
+import { Blossom } from './components/Blossom/Blossom';
 
 document.onreadystatechange = () => {
   if (document.readyState === "complete") {
@@ -17,6 +18,7 @@ document.onreadystatechange = () => {
               <Route path="/" element={<Metadata />} />
               <Route path="/pubkeys" element={<Pubkeys />} />
               <Route path="/kinds" element={<Kinds />} />
+              <Route path="/blossom" element={<Blossom />} />
             </Route>
           </Routes>
         </BrowserRouter>,

--- a/src/utils/blossom.utils.ts
+++ b/src/utils/blossom.utils.ts
@@ -1,0 +1,64 @@
+import { EventHash, getPayloadSha256 } from "./general.utils";
+
+export async function constructBlossomUploadEvent(payload: string) {
+    const createdAt = Math.floor(new Date().getTime() / 1000);
+    return window.nostr?.signEvent({
+        pubkey: await window.nostr?.getPublicKey(),
+        content: "upload file",
+        kind: 24242,
+        created_at: createdAt,
+        tags: [
+            ["t", "upload"],
+            ["expiration", `${createdAt + 3600}`],
+            ["x", payload]
+        ]
+    })
+}
+
+export async function constructBlossomListEvent() {
+    const createdAt = Math.floor(new Date().getTime() / 1000);
+    return window.nostr?.signEvent({
+        pubkey: await window.nostr?.getPublicKey(),
+        content: "list blobs",
+        kind: 24242,
+        created_at: createdAt,
+        tags: [
+            ["t", "list"],
+            ["expiration", `${createdAt + 3600}`],
+        ]
+    });
+}
+
+export async function constructBlossomDeleteEvent(hash: string) {
+    const createdAt = Math.floor(new Date().getTime() / 1000);
+    return window.nostr?.signEvent({
+        pubkey: await window.nostr?.getPublicKey(),
+        content: "delete blob",
+        kind: 24242,
+        created_at: Math.floor(new Date().getTime() / 1000),
+        tags: [
+            ["t", "delete"],
+            ["expiration", `${createdAt + 3600}`],
+            ["x", hash]
+        ]
+    });
+}
+
+export async function fromPayload(payload: File): Promise<EventHash> {
+    const payloadHash = await getPayloadSha256(payload);
+    const event = await constructBlossomUploadEvent(payloadHash);
+    const eventBase64 = btoa(JSON.stringify(event));
+    return eventBase64;
+}
+
+export async function fromEvent(): Promise<EventHash> {
+    const event = await constructBlossomListEvent();
+    const eventBase64 = btoa(JSON.stringify(event));
+    return eventBase64;
+}
+
+export async function fromHash(hash: string): Promise<EventHash> {
+    const event = await constructBlossomDeleteEvent(hash);
+    const eventBase64 = btoa(JSON.stringify(event));
+    return eventBase64;
+}

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -21,7 +21,7 @@ async function constructManagementApiEvent(payloadHash: string) {
     })
 }
 
-async function getPayloadSha256(payload: Record<string, unknown>) {
+export async function getPayloadSha256(payload: Record<string, unknown> | File) {
     const encoder = new TextEncoder();
     const data = encoder.encode(JSON.stringify(payload));
     const hashBuffer = await window.crypto.subtle.digest("SHA-256", data);
@@ -32,7 +32,7 @@ async function getPayloadSha256(payload: Record<string, unknown>) {
     return hashHex;
 }
 
-type EventHash = string;
+export type EventHash = string;
 export async function fromPayload(payload: Record<string, unknown>): Promise<EventHash> {
     const payloadHash = await getPayloadSha256(payload);
     const event = await constructManagementApiEvent(payloadHash);


### PR DESCRIPTION
Issue link - https://github.com/Vin-it/norma/issues/1
- Added the ability to upload/show/delete images to/from the blossom server.
   - We are getting all blobs (from all whitelisted users) but we can only delete our own at the moment. This depends on the blossom server implementation.
   - I was testing this against Khatru's blossom implementation which wouldn't let me delete any one else's images (rather it checks for the author and deletes the entry for the hash AND the author)
   - So, the server would have to implement this -> check if the owner is making the request -> if yes, delete regardless of the author -> if no, then use the regular algo
   - I guess it would be even better if the blossom server had a management API like NIP-86 


**Another thing:** not the most efficient as it loads all images every operation (upload / delete), we can probably manage the state locally but will do for the first iteration

