### PR TITLE
feat: support custom relay URL and endpoint

### DIFF
--- a/src/components/Blossom/Blossom.tsx
+++ b/src/components/Blossom/Blossom.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, useEffect, useState } from "react"
 import { fromEvent, fromHash, fromPayload } from "../../utils/blossom.utils";
-import { MANAGER_API_BASE_URL } from "../../utils/general.utils";
 import { loadWhitelist } from "../Pubkeys/api";
+import { UrlStore } from "../../utils/url.store";
 
 
 interface Descriptor {
@@ -23,7 +23,7 @@ export function Blossom() {
         if (!file) return;
 
         const hash = await fromPayload(file);
-        const response = await fetch(`${MANAGER_API_BASE_URL}/upload`, {
+        const response = await fetch(`${UrlStore.getBaseUrl()}/upload`, {
             method: 'PUT', headers: {
                 'content-type': file.type,
                 'content-length': `${file.size}`,
@@ -45,7 +45,7 @@ export function Blossom() {
         const descriptors: Descriptor[] = [];
 
         for (let i = 0; i < pubkeys.length; i++) {
-            const response = await fetch(`${MANAGER_API_BASE_URL}/list/${pubkeys[i].pubkey}`, {
+            const response = await fetch(`${UrlStore.getBaseUrl()}/list/${pubkeys[i].pubkey}`, {
                 method: 'GET', headers: {
                     Authorization: `Nostr ${hash}`
                 },
@@ -62,7 +62,7 @@ export function Blossom() {
         const authToken = await fromHash(hash);
 
         const response = await fetch(
-            `${MANAGER_API_BASE_URL}/${hash}`,
+            `${UrlStore.getBaseUrl()}/${hash}`,
             { method: 'DELETE', headers: { Authorization: `Nostr ${authToken}` } }
         );
 

--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { loadMetadata, loadSupportedMethods } from "./api";
 import { makeReq } from "../../utils/api.utils";
-
-const RELAY_URL = process.env.RELAY_URL || '';
+import { UrlStore } from "../../utils/url.store";
 
 interface Metadata {
     name: string;
@@ -14,6 +13,10 @@ interface Metadata {
 export default function Metadata() {
     const [metadata, setMetadata] = useState<Metadata>({ name: '', pubkey: '', description: '', icon: '' });
     const [supportedMethods, setSupportedMethods] = useState<string[]>([]);
+    const [api, setApi] = useState({
+        MANAGER_API_BASE_URL: UrlStore.getBaseUrlUnsafe(),
+        MANAGER_API_ENDPOINT: UrlStore.getManagerEndpointUnsafe()
+    })
 
     const loadData = async () => {
         const supportedMethods = await loadSupportedMethods();
@@ -24,7 +27,7 @@ export default function Metadata() {
 
     useEffect(() => {
         loadData();
-    }, []);
+    }, [api.MANAGER_API_BASE_URL, api.MANAGER_API_ENDPOINT]);
 
     const handleRelayNameUpdate = async (name: string) => {
         const res = await makeReq({ method: "changerelayname", params: [name] });
@@ -56,6 +59,39 @@ export default function Metadata() {
         return false;
     }
 
+    const handleBaseUrlUpdate = async (baseUrl: string) => {
+        setApi(prevState => ({
+            ...prevState,
+            MANAGER_API_BASE_URL: baseUrl,
+        }));
+        return true;
+    }
+    const handleEndpointUpdate = async (endpoint: string) => {
+        setApi(prevState => ({
+            ...prevState,
+            MANAGER_API_ENDPOINT: endpoint,
+        }));
+        return true;
+    }
+
+    const handleSaveUrl = (baseUrl: string, endpoint: string) => {
+        if (!baseUrl || !endpoint) {
+            return false;
+        }
+
+        UrlStore.setBaseUrl(baseUrl);
+        UrlStore.setEndpoint(endpoint);
+        setApi({
+            MANAGER_API_BASE_URL: baseUrl,
+            MANAGER_API_ENDPOINT: endpoint,
+        });
+        return true;
+    }
+
+    if (!api.MANAGER_API_BASE_URL || !api.MANAGER_API_ENDPOINT) {
+        return <InitializeApp handleSaveUrl={handleSaveUrl} />
+    }
+
     return (
         <>
             <div className="metadata">
@@ -68,14 +104,49 @@ export default function Metadata() {
                 <EditableInput
                     display="Icon Url" value={metadata.icon}
                     func={handleIconUpdate} />
-                <span><b>Relay:</b> {RELAY_URL}</span>
+                <EditableInput
+                    display="Relay Management API URL" value={api.MANAGER_API_BASE_URL ?? ''}
+                    func={handleBaseUrlUpdate} />
+                <EditableInput
+                    display="Relay Management API Endpoint" value={api.MANAGER_API_ENDPOINT ?? ''}
+                    func={handleEndpointUpdate} />
                 <span><b>Owner:</b> {metadata.pubkey}</span>
                 <div className="supported-methods">
                     <span><b>Supported Methods:</b></span>
-                    {supportedMethods.map((s, idx) => <span>{' '}✅ {s} {idx === supportedMethods.length ? ',' : ''}</span>)}
+                    {supportedMethods.map((s, idx) => <span key={idx}>{' '}✅ {s} {idx === supportedMethods.length ? ',' : ''}</span>)}
                 </div>
+                <button onClick={() => {
+                    const confirmed = confirm("are you sure?");
+                    if (confirmed) {
+                        localStorage.clear();
+                        setApi({
+                            MANAGER_API_BASE_URL: null,
+                            MANAGER_API_ENDPOINT: null,
+                        });
+                    }
+                }}>⚠️ RESET</button>
             </div>
         </>
+    )
+}
+
+function InitializeApp({ handleSaveUrl }: { handleSaveUrl: (baseUrl: string, endpoint: string) => boolean }) {
+    const [baseUrl, setBaseUrl] = useState('');
+    const [endpoint, setEndpoint] = useState('');
+
+    return (
+        <div>
+            Relay Base Url: <input type="text" value={baseUrl}
+                onChange={(e) => setBaseUrl(e.currentTarget.value)} placeholder="Example, http://myrelay.com"
+            />
+            Relay management endpoint: <input type="text" value={endpoint}
+                onChange={(e) => setEndpoint(e.currentTarget.value)} placeholder="Example, /admin/manager"
+            />
+            <button onClick={() => {
+                if (!baseUrl || !endpoint) return;
+                handleSaveUrl(baseUrl, endpoint)
+            }}>Save</button>
+        </div>
     )
 }
 

--- a/src/components/Metadata/api.ts
+++ b/src/components/Metadata/api.ts
@@ -1,9 +1,9 @@
 import { makeReq } from "../../utils/api.utils";
-import { MANAGER_API_BASE_URL } from "../../utils/general.utils";
+import { UrlStore } from "../../utils/url.store";
 
 export async function loadMetadata() {
     const res = await fetch(
-        `${MANAGER_API_BASE_URL}`,
+        `${UrlStore.getBaseUrl()}`,
         {
             method: 'GET',
             headers: {

--- a/src/utils/api.utils.ts
+++ b/src/utils/api.utils.ts
@@ -1,10 +1,11 @@
-import { MANAGER_API_BASE_URL, fromPayload } from "./general.utils";
+import { fromPayload } from "./general.utils";
+import { UrlStore } from "./url.store";
 
 export async function makeReq(payload: Record<string, unknown>) {
     const eventBase64 = await fromPayload(payload);
 
     return fetch(
-        `${MANAGER_API_BASE_URL}/admin/manage`,
+        UrlStore.getFullManagerUrl(),
         {
             method: 'POST',
             body: JSON.stringify(payload),

--- a/src/utils/general.utils.ts
+++ b/src/utils/general.utils.ts
@@ -1,7 +1,5 @@
 import { bech32 } from '@scure/base';
 
-export const MANAGER_API_BASE_URL = process.env.MANAGER_API_BASE_URL || 'http://localhost:8080';
-
 declare global {
     interface Window {
         nostr?: {

--- a/src/utils/url.store.ts
+++ b/src/utils/url.store.ts
@@ -1,0 +1,47 @@
+export class UrlStore {
+    /**
+     * This should be the base domain like https://myrelayurl.com, http(s) not ws(s)!
+     */
+    private static MANAGER_API_BASE_URL: string | null = localStorage.getItem('MANAGER_API_BASE_URL');
+    /**
+     * This should the endpoint like /admin/manage MANAGER_API_BASE_URL + MANAGER_API_ENDPOINT
+     * should give the full URL like https://myrelayurl.com/admin/manage for calling the RPC like nip-86
+     */
+    private static MANAGER_API_ENDPOINT: string | null = localStorage.getItem('MANAGER_API_ENDPOINT');
+
+    static setBaseUrl(value: string) {
+        this.MANAGER_API_BASE_URL = value;
+        localStorage.setItem('MANAGER_API_BASE_URL', value);
+    }
+
+    static setEndpoint(value: string) {
+        this.MANAGER_API_ENDPOINT = value;
+        localStorage.setItem('MANAGER_API_ENDPOINT', value);
+    }
+
+    static getBaseUrlUnsafe() {
+        return this.MANAGER_API_BASE_URL;
+    }
+
+    static getManagerEndpointUnsafe() {
+        return this.MANAGER_API_ENDPOINT;
+    }
+
+    static getBaseUrl() {
+        if (!this.MANAGER_API_BASE_URL) throw Error('MANAGER_API_BASE_URL is not set!');
+        return this.MANAGER_API_BASE_URL;
+    }
+
+    static getEndpoint() {
+        if (!this.MANAGER_API_ENDPOINT) throw Error('MANAGER_API_ENDPOINT is not set!');
+        return this.MANAGER_API_ENDPOINT;
+    }
+
+    static getFullManagerUrl() {
+        if (!this.MANAGER_API_BASE_URL || !this.MANAGER_API_ENDPOINT)
+            throw new Error('Both MANAGER_API_BASE_URL and MANAGER_API_ENDPOINT must be set');
+        return `${this.MANAGER_API_BASE_URL}${this.MANAGER_API_ENDPOINT}`;
+    }
+}
+
+


### PR DESCRIPTION
So far the only way to connect a relay was to add a base url (like http://myrelay.com) with a hardcoded (/admin/manage) endpoint. So to use this app you'd have to download it and run it locally with your own env variables or deploy it with your env variables if you wanted to host it.

But if we allow the ability to add/change base url and endpoint and then host this app somewhere anyone can use it directly without having to build it and then host it or use it locally.

This opens the possibility for allowing non-technical folks to use it to manage their relay, and doesn't do anything to restrict from using it locally or hosting it for anyone who'd like to.