### PR TITLE
chore: prevent nostr extension from triggering before app is initialized

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -43,13 +43,6 @@ a {
   font-weight: 700;
 }
 
-.content p {
-  font-size: 1.2rem;
-  font-weight: 400;
-  opacity: 0.5;
-}
-
-
 .metadata {
   display: flex;
   flex-direction: column;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,24 +4,63 @@ import { Outlet } from "react-router";
 import './App.css';
 import 'milligram/dist/milligram.min.css';
 
+import { useState } from 'react';
+import { UrlContext } from './UrlContext';
+import { useUrlStore } from './use-url-store';
 
 const App = () => {
-  return (
-    <div className="content">
-      <div className="navbar">
-        <div className="navbar-left">
-          <h2 className="title">Relay Management Panel</h2>
-        </div>
-        <div className="navbar-right">
-          <Link to="/">Home</Link>
-          <Link to="/pubkeys">Pubkeys</Link>
-          <Link to="/kinds">Kinds</Link>
-          <Link to="/blossom">Blossom</Link>
-        </div>
-      </div>
-      <Outlet />
-    </div>
-  );
+	const { isStoreInit, api, handleSetApi, resetStore } = useUrlStore();
+
+	return (
+		<UrlContext.Provider value={{ api, handleSetApi, resetStore }}>
+			<div className="content">
+				<div className="navbar">
+					<div className="navbar-left">
+						<h2 className="title">Relay Management Panel</h2>
+					</div>
+					{isStoreInit ?
+						<div className="navbar-right">
+							<Link to="/">Home</Link>
+							<Link to="/pubkeys">Pubkeys</Link>
+							<Link to="/kinds">Kinds</Link>
+							<Link to="/blossom">Blossom</Link>
+						</div> : null}
+				</div>
+
+				{isStoreInit ? <Outlet /> : <InitializeApp handleSetApi={handleSetApi} />}
+			</div>
+		</UrlContext.Provider>
+	);
 };
 
 export default App;
+
+
+function InitializeApp({ handleSetApi }: { handleSetApi: (baseUrl: string, endpoint: string) => void }) {
+	const [baseUrl, setBaseUrl] = useState('');
+	const [endpoint, setEndpoint] = useState('');
+
+	return (
+		<div>
+			<p>To get started, we need two things entered below.</p> 
+			<p>First, please enter "Relay base url", which is the http(s)
+				(not wss!) URL of your relay without the endpoint path. For example, https://myrelay.com 
+			</p>
+			<p>
+				Second, please enter the "Relay management endpoint path", so we know where to send NIP-86 
+				requests. For example, /admin/manage. 
+				Both values combined it would look like https://myrelay.com/manage
+			</p>
+			Relay base url: <input type="text" value={baseUrl}
+				onChange={(e) => setBaseUrl(e.currentTarget.value)} placeholder="Example, http://myrelay.com"
+			/>
+			Relay management endpoint: <input type="text" value={endpoint}
+				onChange={(e) => setEndpoint(e.currentTarget.value)} placeholder="Example, /admin/manage"
+			/>
+			<button onClick={() => {
+				if (!baseUrl || !endpoint) return;
+				handleSetApi(baseUrl, endpoint)
+			}}>Save</button>
+		</div>
+	)
+}

--- a/src/UrlContext.ts
+++ b/src/UrlContext.ts
@@ -1,0 +1,22 @@
+import { createContext, useContext } from "react";
+
+export interface ApiObject {
+    MANAGER_API_BASE_URL: string | null;
+    MANAGER_API_ENDPOINT: string | null;
+}
+
+export interface UrlContext {
+    api: ApiObject
+    handleSetApi: (baseUrl?: string, endpoint?: string) => void
+    resetStore: () => void;
+}
+export const UrlContext = createContext<UrlContext | null>(null);
+
+export const useUrlContext = () => {
+    const urlContext = useContext(UrlContext);
+    if (!urlContext) {
+        throw new Error('Url context was used before init');
+    }
+
+    return urlContext;
+}

--- a/src/use-url-store.ts
+++ b/src/use-url-store.ts
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { UrlStore } from "./utils/url.store";
+
+export const useUrlStore = () => {
+    const [api, setApi] = useState({
+        MANAGER_API_BASE_URL: UrlStore.getBaseUrlUnsafe(),
+        MANAGER_API_ENDPOINT: UrlStore.getManagerEndpointUnsafe()
+    });
+
+    const handleSetApi = (baseUrl?: string, endpoint?: string) => {
+        let localBaseURl = baseUrl ?? UrlStore.getBaseUrl();
+        let localEndpoint = endpoint ?? UrlStore.getEndpoint();
+
+        UrlStore.setBaseUrl(localBaseURl);
+        UrlStore.setEndpoint(localEndpoint);
+        setApi({
+            MANAGER_API_BASE_URL: localBaseURl,
+            MANAGER_API_ENDPOINT: localEndpoint,
+        });
+    }
+
+    const resetStore = () => {
+        setApi({
+            MANAGER_API_BASE_URL: null,
+            MANAGER_API_ENDPOINT: null,
+        })
+        UrlStore.resetStore();
+    }
+
+    return {
+        isStoreInit: Boolean(api.MANAGER_API_BASE_URL && api.MANAGER_API_ENDPOINT),
+        api,
+        handleSetApi,
+        resetStore,
+    }
+
+}

--- a/src/utils/url.store.ts
+++ b/src/utils/url.store.ts
@@ -19,6 +19,11 @@ export class UrlStore {
         localStorage.setItem('MANAGER_API_ENDPOINT', value);
     }
 
+    static resetStore() {
+        localStorage.removeItem('MANAGER_API_ENDPOINT');
+        localStorage.removeItem('MANAGER_API_BASE_URL');
+    }
+
     static getBaseUrlUnsafe() {
         return this.MANAGER_API_BASE_URL;
     }


### PR DESCRIPTION
The extension would ask for permissions for event signinng before the base url was set. This is due to the fact that the app initialization happened inside one of the components of the application (Metadata), so the whole component had to load to render InitializeApp.

This does not make sense as InitializeApp was supposed to take in the input that's required for initializing the whole application. Loading this component after part of the app is initialized and inside of another component is wrong.

In this PR, we are improving things by moving this component to a higher level in the main App component. This way we can also hide the navigation and prevent rendering of outlets in case someone tries to navigate manually through the browser navigation bar.