### PR TITLE
fix(metadata): EditableInput not allowed to be empty / state did not update with the api

### DIFF
--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -67,18 +67,27 @@ export default function Metadata() {
 				<EditableInput
 					display="Name"
 					value={metadata.name}
-					func={changeRelayName}
+					func={async (name: string) => {
+						setMetadata((prevState) => ({ ...prevState, name }));
+						return changeRelayName(name);
+					}}
 				/>
 				<EditableInput
 					display="Description"
 					value={metadata.description}
-					func={changeRelayDescription}
+					func={async (desc: string) => {
+						setMetadata((prevState) => ({ ...prevState, description: desc }));
+						return changeRelayDescription(desc);
+					}}
 				/>
 				<EditableInput
 					style={{ overflowWrap: 'anywhere' }}
 					display="Icon Url"
 					value={metadata.icon}
-					func={changeRelayIcon}
+					func={async (url: string) => {
+						setMetadata((prevState) => ({ ...prevState, icon: url }));
+						return changeRelayIcon(url);
+					}}
 				/>
 				<EditableInput
 					display="Relay Management API URL"
@@ -137,11 +146,15 @@ function EditableInput({ display, value, func, style }: EditableInputProps) {
 	const [error, setError] = useState<string>('');
 
 	useEffect(() => {
-		if (!inputValue) setInputValue(value);
-	}, [value, inputValue]);
+		setInputValue(value);
+	}, [value]);
 
 	const handleSaveClick = async () => {
 		setEditing(false);
+		if (!inputValue) {
+			setInputValue(value);
+			return;
+		}
 		const response = await func(inputValue);
 		if (response.error) {
 			setInputValue(value);


### PR DESCRIPTION


Two bugs -
1. If the input was empty (falsy) !inputValue condition would trigger and the original value would fill in. AKA the input couldn't be empty and rewritten to a new one.

2. EditableInput has a local state to handle the input text, but Metadata passes the state that's in sync with the API (or we would have to pull the state in EditableInput, but as I write this maybe that's fine? anyways we send the data from EditableInput? I will rethink and revisit this.) For now, the function that sends to the API also updates the state in the parent component